### PR TITLE
Code cleanup - Move Config struct to a library file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ version = "1.0.1"
 edition = "2021"
 description = "A simple tool to copy screenshots from across all MultiMC instances to a specified folder."
 repository = "https://github.com/jr0dsgarage/mc_screenshot_copy.git"
-license = "GNU GPLv3"
 license-file = "LICENSE"
 readme = "README.md"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,98 @@
+/// Struct to hold the configuration for the application.
+use std::{fs, io::{self, Write}, path::Path};
+use colored::*;
+pub struct Config {
+    pub multimc_folder: String,
+    pub output_folder: String,
+}
+
+impl Config {
+    /// Creates a new Config instance from command-line arguments or prompts the user for input.
+    pub fn new(args: &[String]) -> Config {
+        let multimc_folder: String;
+        let output_folder: String;
+
+        if args.len() != 3 {
+            println!("Typical command prompt Usage: {} {}",
+                Path::new(&args[0]).file_name().unwrap().to_str().unwrap().bright_green(),
+                "<MultiMC folder path> <output folder path>".bright_green());
+            println!("{}","Not enough arguments provided, prompting for folder paths...".bright_red());
+            multimc_folder = Self::folder_prompt("Please enter the MultiMC folder path: ");
+            output_folder = Self::folder_prompt("Please enter the desired output folder path: ");
+        } else {
+            multimc_folder = args[1].clone();
+            output_folder = args[2].clone();
+        }
+
+        let config: Config = Config { multimc_folder, output_folder };
+        config.validate()
+    }
+
+        /// Validates the configuration and re-prompts the user for valid inputs if necessary.
+        fn validate(mut self) -> Config {
+            loop {
+                if let Err(e) = self.validate_multimc_folder() {
+                    println!("Error: {}", e.bright_red());
+                    self.multimc_folder = Self::folder_prompt("Please enter a valid MultiMC folder path: ");
+                    continue;
+                }
+                break;
+            }
+    
+            loop {
+                if let Err(e) = self.validate_output_folder() {
+                    println!("Error: {}", e.bright_red());
+                    self.output_folder = Self::folder_prompt("Please enter a valid output folder path: ");
+                    continue;
+                }
+                break;
+            }
+    
+            self
+        }
+    
+
+    /// Validates the MultiMC folder path.
+    fn validate_multimc_folder(&self) -> Result<(), String> {
+        if self.multimc_folder.is_empty() {
+            Err("No input given for the MultiMC folder".to_string())
+        } else if !Path::new(&self.multimc_folder).exists() {
+            Err("The MultiMC folder provided does not exist".to_string())
+        } else {
+            let instance_folder = Path::new(&self.multimc_folder).join("instances");
+            if !instance_folder.exists() {
+                Err("The MultiMC folder does not contain an 'instances' folder".to_string())
+            } else if fs::read_dir(instance_folder).map_err(|e| e.to_string())?.next().is_none() {
+                Err("The 'instances' folder does not contain any instance folders".to_string())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Validates the output folder path and creates the folder if it doesn't exist.
+    pub fn validate_output_folder(&self) -> Result<(), String> {
+        if self.output_folder.is_empty() {
+            Err("No value given for the output folder".to_string())
+        } else if !Path::new(&self.output_folder).exists() {
+            if let Err(e) = fs::create_dir_all(&self.output_folder) {
+                Err(format!("Failed to create output folder: {}", e.to_string()))
+            } else {
+                Ok(())
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Prompts the user for a folder path.
+    fn folder_prompt(prompt: &str) -> String {
+        print!("{}", prompt.bright_green());
+        io::stdout().flush().expect("Failed to flush stdout");
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).expect("Failed to read line");
+        input.trim().to_string()
+    }
+    
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ impl Config {
     /// Creates a new Config instance from command-line arguments or prompts the user for input.
     fn new(args: &[String]) -> Config {
         if args.len() != 3 {
-            let exe_name = Path::new(&args[0]).file_name().unwrap().to_str().unwrap();
-            println!("Typical command prompt Usage: {} <MultiMC folder> <output folder>", exe_name);
+            println!("Typical command prompt Usage: {} <MultiMC folder> <output folder>",
+                Path::new(&args[0]).file_name().unwrap().to_str().unwrap());
             println!("{}","No arguments provided, prompting for folders...".bright_red());
             let multimc_folder = folder_prompt("Please enter the MultiMC folder: ");
             let output_folder = folder_prompt("Please enter the output folder: ");
@@ -48,9 +48,10 @@ impl Config {
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let config: Config = Config::new(&args);
     setup_terminal();
     print_title();
+    
+    let config: Config = Config::new(&args);
     config.setup();
 
     let instance_folders = match get_instance_folders(&config.multimc_folder) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,91 +1,22 @@
-use std::{io::{self, Write, Read}, env, fs, path::{Path, PathBuf}};
+use std::{io::Read, env, fs, path::{Path, PathBuf}};
+use mc_screenshot_copy::config::Config;
 use colored::*;
 
-/// Struct to hold the configuration for the application.
-struct Config {
-    multimc_folder: String,
-    output_folder: String,
-}
-
-impl Config {
-    /// Creates a new Config instance from command-line arguments or prompts the user for input.
-    fn new(args: &[String]) -> Config {
-        if args.len() != 3 {
-            println!("Typical command prompt Usage: {} <MultiMC folder> <output folder>",
-                Path::new(&args[0]).file_name().unwrap().to_str().unwrap());
-            println!("{}","No arguments provided, prompting for folders...".bright_red());
-            let multimc_folder = folder_prompt("Please enter the MultiMC folder: ");
-            let output_folder = folder_prompt("Please enter the output folder: ");
-            Config { multimc_folder, output_folder }
-        } else {
-            Config { multimc_folder: args[1].clone(), output_folder: args[2].clone() }
-        }
-    }
-
-    /// Validates the MultiMC folder path.
-    fn validate_multimc_folder(&self) -> Result<(), String> {
-        if self.multimc_folder.is_empty() {
-            Err("No input given for the MultiMC folder".to_string())
-        } else if !Path::new(&self.multimc_folder).exists() {
-            Err("The MultiMC folder provided does not exist or does not include MultiMC.exe".to_string())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Validates the output folder path and creates the folder if it doesn't exist.
-    fn validate_output_folder(&self) -> Result<(), String> {
-        if self.output_folder.is_empty() {
-            Err("No input given for the output folder".to_string())
-        } else if !Path::new(&self.output_folder).exists() {
-            if let Err(e) = fs::create_dir_all(&self.output_folder) {
-                Err(format!("Failed to create output folder: {}", e.to_string()))
-            } else {
-                Ok(())
-            }
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Sets up the configuration by validating the MultiMC folder and creating the output folder if necessary.
-    fn setup(&self) -> Result<(), String> {
-        self.validate_multimc_folder()?;
-        self.validate_output_folder()?;
-        Ok(())
-    }
-    
-
-}
-
 fn main() {
-    let args: Vec<String> = env::args().collect();
     setup_terminal();
     print_title();
     
+    let args: Vec<String> = env::args().collect();
     let config: Config = Config::new(&args);
-    if let Err(e) = config.setup() {
-        println!("{}", e.bright_red());
-        await_exit_confirmation();
-        return;
-    }
-
-    let instance_folders = match get_instance_folders(&config.multimc_folder) {
-        Ok(folders) => folders,
-        Err(_e) => {
-            println!("{}","The MultiMC folder provided is not valid, please use the folder that contains MultiMC.exe".bright_red());
-            Vec::new()
-        }
-    };
-
-    let total_screenshots = copy_screenshots(instance_folders, &config.output_folder);
+    let instance_folders: Vec<PathBuf> = get_instance_folders(&config.multimc_folder);
+    let total_screenshots: usize = copy_screenshots(instance_folders, &config.output_folder);
 
     println!("{} {}", "Total screenshots copied:".magenta(), total_screenshots.to_string().bright_green());
 
     await_exit_confirmation();
 }
 
-/// Sets up the terminal to enable colors
+/// Sets up the terminal to enable colors on Windows.
 fn setup_terminal() {
     if cfg!(target_os = "windows") {
         control::set_virtual_terminal(true).unwrap();
@@ -105,29 +36,24 @@ fn print_title() {
     println!("{}", "=".repeat(title.len()).cyan());
 }
 
-/// Prompts the user for a folder path.
-fn folder_prompt(prompt: &str) -> String {
-    print!("{}", prompt.bright_green());
-    io::stdout().flush().expect("Failed to flush stdout");
-    let mut input = String::new();
-    io::stdin().read_line(&mut input).expect("Failed to read line");
-    input.trim().to_string()
-}
-
 /// Gets the instance folders from the MultiMC folder.
-fn get_instance_folders(multimc_folder: &str) -> Result<Vec<PathBuf>, io::Error> {
-    let instance_folder = PathBuf::from(multimc_folder).join("instances");
-    let mut folders = Vec::new();
-    for entry in fs::read_dir(instance_folder)? {
-        let entry = entry?;
-        if entry.path().is_dir() {
-            folders.push(entry.path());
+fn get_instance_folders(multimc_folder: &str) -> Vec<PathBuf> {
+    let instance_folder: PathBuf = PathBuf::from(multimc_folder).join("instances");
+    let mut folders: Vec<PathBuf> = Vec::new();
+    if let Ok(entries) = fs::read_dir(instance_folder) {
+        for entry in entries {
+            if let Ok(entry) = entry {
+                if entry.path().is_dir() {
+                    folders.push(entry.path());
+                }
+            }
         }
     }
-    Ok(folders)
+    folders
 }
 
 /// Copies the screenshots from the /.minecraft/screenshots folder within the MultiMC instances to the output folder.
+/// Returns the total number of screenshots copied.
 fn copy_screenshots(instance_folders: Vec<PathBuf>, output_folder: &str) -> usize {
     let mut total_screenshots = 0;
 
@@ -149,7 +75,7 @@ fn copy_screenshots(instance_folders: Vec<PathBuf>, output_folder: &str) -> usiz
             }
         }
     }
-
+    
     total_screenshots
 }
 


### PR DESCRIPTION
The code was getting a little cumbersome being all in one file, so I migrated the Config struct and its implemenation into a library file.

The folder validation was also sketchy, so I shored it up by looping over each validation until it passes, forcing a re-prompt of the user for the information, rather than exiting the application immediately.